### PR TITLE
Use public folder favicon and manifest

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2,10 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <link
-      rel="icon"
-      href="https://portal.villagebookbuilders.org/favicon.ico"
-    />
+    <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
     <meta
       name="viewport"
       content="width=device-width, initial-scale=1, shrink-to-fit=no"
@@ -15,10 +12,7 @@
       name="description"
       content="Village Book Builders Portal - Let's give hope to children through mentoring."
     />
-    <link
-      rel="manifest"
-      href="https://portal.villagebookbuilders.org/manifest.json"
-    />
+    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
     <!-- Added Bootstrap -->
     <link
       rel="stylesheet"


### PR DESCRIPTION
- Update index.html to reference the favicon and manifest from this project

I think this makes sense, because if this project gets deployed and takes over the same URL `portal.villagebookbuilders.org/`  then the linking to the favicon won't work, unless we include the assets in the build etc. 

It can't exist if we don't deploy it kind of thing. At least that's my expectation. 