### PR TITLE
Add `lint` script - reorder `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,14 @@
   "name": "front-end",
   "version": "0.1.0",
   "private": true,
+  "scripts": {
+    "build": "craco build",
+    "eject": "react-scripts eject",
+    "lint": "eslint .",
+    "local": "react-scripts start",
+    "start": "craco start",
+    "test": "craco test"
+  },
   "dependencies": {
     "@ant-design/icons": "^4.5.0",
     "@craco/craco": "^5.8.0",
@@ -27,13 +35,6 @@
     "redux-thunk": "^2.3.0",
     "yargs-parser": "^15.0.1"
   },
-  "scripts": {
-    "start": "craco start",
-    "build": "craco build",
-    "test": "craco test",
-    "eject": "react-scripts eject",
-    "local": "react-scripts start"
-  },
   "eslintConfig": {
     "extends": "react-app"
   },
@@ -50,10 +51,11 @@
     ]
   },
   "devDependencies": {
-    "eslint-config-prettier": "^7.1.0",
-    "prettier": "^2.2.1",
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.5.0",
-    "@testing-library/user-event": "^7.2.1"
+    "@testing-library/user-event": "^7.2.1",
+    "eslint-config-prettier": "^7.1.0",
+    "prettier": "^2.2.1",
+    "typescript": "^4.2.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3706,11 +3706,6 @@ cosmiconfig@^6.0.0:
     path-type "^4.0.0"
     yaml "^1.7.2"
 
-country-codes-list@^1.6.8:
-  version "1.6.8"
-  resolved "https://registry.yarnpkg.com/country-codes-list/-/country-codes-list-1.6.8.tgz#c6ff506d3c0511f645fdc0997d0b4fa6773d043e"
-  integrity sha512-wsqH44Yx3pTyPA77jYt2Nxso6kXziMwxI37fJFQLcd/3ome8Gqz6areaeG1w8zfeU9i+cZvJA3k2Mo5EW7rAtg==
-
 craco-less@^1.17.1:
   version "1.17.1"
   resolved "https://registry.yarnpkg.com/craco-less/-/craco-less-1.17.1.tgz#aa23cf10d09f0f99657bed977788cc9b501add70"
@@ -12613,6 +12608,11 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
+
+typescript@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.3.tgz#39062d8019912d43726298f09493d598048c1ce3"
+  integrity sha512-qOcYwxaByStAWrBf4x0fibwZvMRG+r4cQoTjbPtUlrWjBHbmCAww1i448U0GJ+3cNNEtebDteo/cHOR3xJ4wEw==
 
 uid-number@0.0.6:
   version "0.0.6"


### PR DESCRIPTION
- Add `lint` script
- Move scripts earlier in package file - common convention/default CRA/ easier to get started with the repo

*Typescript needed as dev dependency for lint because peer deps require it 

Then next want to add a pre push hook to run `lint`, but do want to ask team for feedback on that before adding the pre push hook. 