### PR TITLE
deregister service worker for now

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,13 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import registerServiceWorker from './registerServiceWorker';
+// import registerServiceWorker from './registerServiceWorker';
 import App from './containers/App';
 
 ReactDOM.render(<App />, document.getElementById('root'));
 
-registerServiceWorker();
+/** FUTURE: Put back when in production / after launch
+ * registering this can lead to dev seeing old versions of platform
+ * https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API
+ */
+
+// registerServiceWorker();


### PR DESCRIPTION
- Service worker may serve cached / previous versions of platform
- Great when in prod, for now leave disabled